### PR TITLE
Added offset parameter to open() and ReadBuffer

### DIFF
--- a/python/src/cloudstorage/cloudstorage_api.py
+++ b/python/src/cloudstorage/cloudstorage_api.py
@@ -67,6 +67,8 @@ def open(filename,
     retry_params: An instance of api_utils.RetryParams for subsequent calls
       to GCS from this file handle. If None, the default one is used.
     _account_id: Internal-use only.
+    offset: Number of bytes to skip at the start of the file. If None, 0 is
+      used.
 
   Returns:
     A reading or writing buffer that supports File-like interface. Buffer

--- a/python/src/cloudstorage/cloudstorage_api.py
+++ b/python/src/cloudstorage/cloudstorage_api.py
@@ -41,6 +41,7 @@ def open(filename,
          mode='r',
          content_type=None,
          options=None,
+         offset=0,
          read_buffer_size=storage_api.ReadBuffer.DEFAULT_BUFFER_SIZE,
          retry_params=None,
          _account_id=None):
@@ -91,6 +92,7 @@ def open(filename,
                        'for writing mode.')
     return storage_api.ReadBuffer(api,
                                   filename,
+                                  offset=offset,
                                   buffer_size=read_buffer_size)
   else:
     raise ValueError('Invalid mode %s.' % mode)

--- a/python/src/cloudstorage/storage_api.py
+++ b/python/src/cloudstorage/storage_api.py
@@ -194,6 +194,8 @@ class ReadBuffer(object):
         one buffer. But there may be a pending future that contains
         a second buffer. This size must be less than max_request_size.
       max_request_size: Max bytes to request in one urlfetch.
+      offset: Number of bytes to skip at the start of the file. If None, 0 is
+        used.
     """
     self._api = api
     self._path = path

--- a/python/src/cloudstorage/storage_api.py
+++ b/python/src/cloudstorage/storage_api.py
@@ -182,6 +182,7 @@ class ReadBuffer(object):
   def __init__(self,
                api,
                path,
+               offset=0,
                buffer_size=DEFAULT_BUFFER_SIZE,
                max_request_size=MAX_REQUEST_SIZE):
     """Constructor.
@@ -202,11 +203,11 @@ class ReadBuffer(object):
     assert buffer_size <= max_request_size
     self._buffer_size = buffer_size
     self._max_request_size = max_request_size
-    self._offset = 0
+    self._offset = offset
     self._buffer = _Buffer()
     self._etag = None
 
-    get_future = self._get_segment(0, self._buffer_size, check_response=False)
+    get_future = self._get_segment(offset, self._buffer_size, check_response=False)
 
     status, headers, content = self._api.head_object(path)
     errors.check_status(status, [200], path, resp_headers=headers, body=content)


### PR DESCRIPTION
I found it useful to be able to use the offset reading functionality in GCS, so added it as an optional default parameter to open(), with the corresponding change in ReadBuffer.