### PR TITLE
Load metadata from Blobstore API (as a backup) when running locally

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/cloudstorage/dev/LocalRawGcsService.java
+++ b/java/src/main/java/com/google/appengine/tools/cloudstorage/dev/LocalRawGcsService.java
@@ -633,6 +633,9 @@ final class LocalRawGcsService implements RawGcsService {
     boolean fromBlobstore = false;
     if (!dsResults.hasNext()) {
       // If no results, perhaps there's metadata stored by the Blobstore API that we missed.
+      // Note that Blobstore metadata results aren't returned if some blobs are uploaded via
+      // Blobstore and others are uploaded using this client library.  We only check for Blobstore
+      // metadata if no results are found in appengine-gcs-client's metadata store.
       Query blobstoreQuery = makeBlobstoreQuery();
       dsResults = datastore.prepare(blobstoreQuery).asQueryResultIterator(fetchOptions);
       fromBlobstore = true;

--- a/java/src/main/java/com/google/appengine/tools/cloudstorage/dev/LocalRawGcsService.java
+++ b/java/src/main/java/com/google/appengine/tools/cloudstorage/dev/LocalRawGcsService.java
@@ -19,6 +19,7 @@ package com.google.appengine.tools.cloudstorage.dev;
 import static com.google.appengine.api.datastore.Entity.KEY_RESERVED_PROPERTY;
 import static com.google.appengine.api.datastore.Query.FilterOperator.GREATER_THAN_OR_EQUAL;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.io.BaseEncoding.base64Url;
 
 import com.google.appengine.api.NamespaceManager;
 import com.google.appengine.api.ThreadManager;
@@ -103,8 +104,10 @@ final class LocalRawGcsService implements RawGcsService {
   private static final String OPTIONS_PROP = "options";
   private static final String CREATION_TIME_PROP = "time";
   private static final String FILE_LENGTH_PROP = "length";
+  private static final String BLOBSTORE_META_KIND = "__BlobInfo__";
+  private static final String BLOBSTORE_KEY_PREFIX = "encoded_gs_key:";
 
-  private static HashMap<GcsFilename, List<ByteBuffer>> inMemoryData = new HashMap<>();
+  private static final HashMap<GcsFilename, List<ByteBuffer>> inMemoryData = new HashMap<>();
 
   private static class BlobStorageAdapter {
 
@@ -314,11 +317,31 @@ final class LocalRawGcsService implements RawGcsService {
     }
   }
 
+  private Key makeBlobstoreKey(GcsFilename filename) {
+    String origNamespace = NamespaceManager.get();
+    try {
+      NamespaceManager.set("");
+      return KeyFactory.createKey(null, BLOBSTORE_META_KIND, getBlobKeyForFilename(filename).getKeyString());
+    } finally {
+      NamespaceManager.set(origNamespace);
+    }
+  }
+
   private Query makeQuery(String bucket) {
     String origNamespace = NamespaceManager.get();
     try {
       NamespaceManager.set("");
       return new Query(ENTITY_KIND_PREFIX + bucket);
+    } finally {
+      NamespaceManager.set(origNamespace);
+    }
+  }
+
+  private Query makeBlobstoreQuery() {
+    String origNamespace = NamespaceManager.get();
+    try {
+      NamespaceManager.set("");
+      return new Query(BLOBSTORE_META_KIND);
     } finally {
       NamespaceManager.set(origNamespace);
     }
@@ -383,10 +406,15 @@ final class LocalRawGcsService implements RawGcsService {
     Entity entity;
     try {
       entity = datastore.get(null, makeKey(filename));
-    } catch (EntityNotFoundException ex) {
-      return null;
+      return createGcsFileMetadata(entity, filename);
+    } catch (EntityNotFoundException ex1) {
+      try {
+        entity = datastore.get(null, makeBlobstoreKey(filename));
+        return createGcsFileMetadataFromBlobstore(entity, filename);
+      } catch (EntityNotFoundException ex2) {
+        return null;
+      }
     }
-    return createGcsFileMetadata(entity, filename);
   }
 
   private GcsFileMetadata createGcsFileMetadata(Entity entity, GcsFilename filename)
@@ -422,6 +450,15 @@ final class LocalRawGcsService implements RawGcsService {
       length = totalBytesRead;
     }
     return new GcsFileMetadata(filename, options, null, length, creationTime);
+  }
+
+  private GcsFileMetadata createGcsFileMetadataFromBlobstore(Entity entity, GcsFilename filename) {
+    return new GcsFileMetadata(
+        filename,
+        GcsFileOptions.getDefaultInstance(),
+        "",
+        (Long) entity.getProperty("size"),
+        (Date) entity.getProperty("creation"));
   }
 
   @Override
@@ -593,9 +630,24 @@ final class LocalRawGcsService implements RawGcsService {
     Set<String> prefixes = new HashSet<>();
     QueryResultIterator<Entity> dsResults =
         datastore.prepare(query).asQueryResultIterator(fetchOptions);
+    boolean fromBlobstore = false;
+    if (!dsResults.hasNext()) {
+      // If no results, perhaps there's metadata stored by the Blobstore API that we missed.
+      Query blobstoreQuery = makeBlobstoreQuery();
+      dsResults = datastore.prepare(blobstoreQuery).asQueryResultIterator(fetchOptions);
+      fromBlobstore = true;
+    }
     while (items.size() < maxResults && dsResults.hasNext()) {
       Entity entity = dsResults.next();
-      String name = entity.getKey().getName();
+      String name;
+      if (!fromBlobstore) {
+        name = entity.getKey().getName();
+      } else {
+        String encodedName = entity.getKey().getName().substring(BLOBSTORE_KEY_PREFIX.length());
+        String fullName = new String(base64Url().omitPadding().decode(encodedName));
+        String[] nameInfo = fullName.split("/", 4);
+        name = nameInfo[nameInfo.length - 1];
+      }
       if (prefixLength > 0 && !name.startsWith(prefix)) {
         break;
       }
@@ -610,7 +662,12 @@ final class LocalRawGcsService implements RawGcsService {
         }
       }
       GcsFilename filename = new GcsFilename(bucket, name);
-      GcsFileMetadata metadata = createGcsFileMetadata(entity, filename);
+      GcsFileMetadata metadata;
+      if (!fromBlobstore) {
+        metadata = createGcsFileMetadata(entity, filename);
+      } else {
+        metadata = createGcsFileMetadataFromBlobstore(entity, filename);
+      }
       ListItem listItem = new ListItem.Builder()
           .setName(name)
           .setLength(metadata.getLength())
@@ -622,8 +679,6 @@ final class LocalRawGcsService implements RawGcsService {
     String nextMarker = null;
     if (items.size() == maxResults && cursor != null) {
       nextMarker = cursor.toWebSafeString();
-    }
-    if (marker != null && marker.equals(nextMarker)) {
     }
     return new ListItemBatch(items, nextMarker);
   }


### PR DESCRIPTION
There are some users that upload blobs to GCS via the Blobstore API and want to read metadata using appengine-gcs-client.  While this works in production, this client and the Blobstore API store blob metadata differently when running on the local development server.  This PR changes getObjectMetadata and list in LocalRawGcsService to look at the Blobstore API's metadata store if the metadata isn't found in this client's metadata store.