### PR TITLE
Remove listing of Blobstore BlobInfo

### DIFF
--- a/java/src/test/java/com/google/appengine/tools/cloudstorage/LocalRawGcsServiceTest.java
+++ b/java/src/test/java/com/google/appengine/tools/cloudstorage/LocalRawGcsServiceTest.java
@@ -28,9 +28,7 @@ import com.google.appengine.api.blobstore.BlobInfo;
 import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.blobstore.BlobstoreService;
 import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
-import com.google.appengine.api.blobstore.dev.BlobInfoStorage;
 import com.google.appengine.api.blobstore.dev.BlobStorageFactory;
-import com.google.appengine.tools.cloudstorage.RawGcsService.ListItemBatch;
 import com.google.appengine.tools.cloudstorage.dev.LocalRawGcsServiceFactory;
 import com.google.appengine.tools.development.testing.LocalBlobstoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
@@ -51,7 +49,6 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -185,47 +182,6 @@ public class LocalRawGcsServiceTest {
     assertEquals(GcsFileOptions.getDefaultInstance(), metadata.getOptions());
     assertEquals(expectedSize, metadata.getLength());
     assertEquals(Collections.emptyMap(), metadata.getXGoogHeaders());
-  }
-
-  @Test
-  public void testListAfterBlobstoreUpload() throws IOException {
-    Date expectedDate = new Date(12345678L);
-    String expectedFilename = "my-file";
-    long expectedSize = 123456789L;
-    String expectedMd5Hash = "abcdefghijklmnop";
-    BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
-    String bucket = "my-bucket";
-    GcsFilename expectedGcsFilename = new GcsFilename(bucket, expectedFilename);
-    BlobKey expectedKey = blobstoreService.createGsBlobKey(
-        getPathForGcsFilename(expectedGcsFilename));
-    BlobInfoStorage storage = BlobStorageFactory
-        .getBlobInfoStorage();
-    storage.saveBlobInfo(
-            new BlobInfo(
-                expectedKey,
-                "text",
-                expectedDate,
-                expectedFilename,
-                expectedSize,
-                expectedMd5Hash));
-    ListItemBatch batch = rawGcsService.list(bucket, "", "/", null, 2, 0);
-    List<ListItem> items = batch.getItems();
-    assertEquals(1, items.size());
-    ListItem metadata = items.get(0);
-    assertEquals(expectedDate, metadata.getLastModified());
-    assertEquals(expectedSize, metadata.getLength());
-    assertEquals(expectedFilename, metadata.getName());
-
-    // Test with prefix
-    batch = rawGcsService.list(bucket, "my-", "/", null, 2, 0);
-    items = batch.getItems();
-    assertEquals(1, items.size());
-    metadata = items.get(0);
-    assertEquals(expectedDate, metadata.getLastModified());
-    assertEquals(expectedSize, metadata.getLength());
-    assertEquals(expectedFilename, metadata.getName());
-    batch = rawGcsService.list(bucket, "nonexistent-prefix", "/", null, 2, 0);
-    assertEquals(0, batch.getItems().size());
   }
 
   private String getPathForGcsFilename(GcsFilename filename) {


### PR DESCRIPTION
Reverts the listing changes made in #36.  Ideally, we'd return both Blobstore GCS blob metadata and appengine-gcs-client metadata from calls to "list" on local runs.  However, the complexities of handling that don't seem worth it, considering that the Blobstore API is deprecated and this API is no longer preferred (see [gcloud-java](https://github.com/GoogleCloudPlatform/gcloud-java/tree/master/gcloud-java-storage)).  Though #36 partially supporting listing, there could be unexpected behavior where depending on whether or not you happen to upload any blobs using appengine-gcs-client, you may or may not see your GCS objects uploaded via the Blobstore API. 