### PR TITLE
Allow for local credentials

### DIFF
--- a/python/src/cloudstorage/storage_api.py
+++ b/python/src/cloudstorage/storage_api.py
@@ -38,6 +38,7 @@ except ImportError:
   from google.appengine.api import urlfetch
   from google.appengine.ext import ndb
 
+from google.appengine.api import app_identity
 
 
 def _get_storage_api(retry_params, account_id=None):
@@ -50,16 +51,21 @@ def _get_storage_api(retry_params, account_id=None):
 
   Returns:
     A storage_api instance to handle urlfetch work to GCS.
-    On dev appserver, this instance by default will talk to a local stub
-    unless common.ACCESS_TOKEN is set. That token will be used to talk
-    to the real GCS.
+    On dev appserver, this instance will talk to a local stub by default.
+    However, if you pass the arguments --appidentity_email_address and
+    --appidentity_private_key_path to dev_appserver.py it will attempt to use
+    the real GCS with these credentials.  Alternatively, you can set a specific
+    access token with common.set_access_token.  You can also pass
+    --default_gcs_bucket_name to set the default bucket.
   """
 
 
   api = _StorageApi(_StorageApi.full_control_scope,
                     service_account_id=account_id,
                     retry_params=retry_params)
-  if common.local_run() and not common.get_access_token():
+
+  if (common.local_run() and not common.get_access_token()
+      and not app_identity.get_service_account_name()):
     api.api_url = common.local_api_url()
   if common.get_access_token():
     api.token = common.get_access_token()


### PR DESCRIPTION
The existing workflow for using remote GCS in dev is not so good.  You have to manually acquire a token every hour and somehow get it into the code in a way that doesn't affect production deployments.

With this change, passing credentials to dev_appserver.py on the commandline will cause it to use the remote GCS API automatically.

Try it like this:
```
dev_appserver.py app.yaml
  --appidentity_email_address=CLIENT_EMAIL \
  --appidentity_private_key_path=KEY_PATH \
  --default_gcs_bucket_name=BUCKET_NAME
```

`app_identity.get_service_account_name()` evaluates to emptystring unless you passed the appidentity flags.  Note that the file you must pass as the private key has to be in PKCS#1 format for app engine to accept it.