### PR TITLE
Removed application: and version: elements

### DIFF
--- a/python/demo/app.yaml
+++ b/python/demo/app.yaml
@@ -1,5 +1,3 @@
-application: your-app-id
-version: v1
 runtime: python27
 api_version: 1
 threadsafe: yes


### PR DESCRIPTION
Updating [tutorial](https://cloud.google.com/appengine/docs/python/googlecloudstorageclient/app-engine-cloud-storage-sample) to instead use gcloud app deploy, which does not support the application: and version: elements in app.yaml files (command will fail with errors)