### PR TITLE
cloudstorage.compose: Allow one source file

### DIFF
--- a/python/src/cloudstorage/cloudstorage_api.py
+++ b/python/src/cloudstorage/cloudstorage_api.py
@@ -460,9 +460,9 @@ def _validate_compose_list(destination_file, file_list,
     raise ValueError(
           'Compose attempted to create composite with too many'
            '(%i) components; limit is (%i).' % (list_len, number_of_files))
-  if list_len <= 1:
+  if list_len <= 0:
     raise ValueError('Compose operation requires at'
-                     ' least two components; %i provided.' % list_len)
+                     ' least one component; 0 provided.')
 
   if files_metadata is None:
     files_metadata = []

--- a/python/test/cloudstorage_test.py
+++ b/python/test/cloudstorage_test.py
@@ -559,8 +559,18 @@ class CloudStorageComposeTest(unittest.TestCase):
                       [TESTFILE] * 33, DESTFILE)
 
   def testComposeTooFewFilesFailure(self):
-    """Test to ensure ValueError is thrown if less than 2 are sent."""
-    self.assertRaises(ValueError, cloudstorage.compose, [TESTFILE], DESTFILE)
+    """Test to ensure ValueError is thrown if zero paths are sent."""
+    self.assertRaises(ValueError, cloudstorage.compose, [], DESTFILE)
+
+  def testComposeOne(self):
+    """Test to ensure one file can be composed (the API supports it)."""
+
+    test_file = TESTFILE[len(BUCKET) + 1:]
+    cloudstorage.compose([test_file], DESTFILE)
+    with cloudstorage.open(DESTFILE, 'r') as gcs:
+      results = gcs.read()
+    cloudstorage.delete(DESTFILE)
+    self.assertEqual(DEFAULT_COMPOSE_CONTENT, results)
 
   def testComposeFilesMetadataTooLargeFailure(self):
     """Test to ensure ValueError is thrown if metadata is too long."""

--- a/python/test/cloudstorage_test.py
+++ b/python/test/cloudstorage_test.py
@@ -558,7 +558,7 @@ class CloudStorageComposeTest(unittest.TestCase):
     self.assertRaises(ValueError, cloudstorage.compose,
                       [TESTFILE] * 33, DESTFILE)
 
-  def testComposeTooFewFilesFailure(self):
+  def testComposeNoFilesFailure(self):
     """Test to ensure ValueError is thrown if zero paths are sent."""
     self.assertRaises(ValueError, cloudstorage.compose, [], DESTFILE)
 


### PR DESCRIPTION
Previously compose required at least two source files. However, the
API itself works with a single file. This can be verified using gsutil.

```
echo "hello" > example
gsutil cp example gs://test_bucket
gsutil -D compose gs://test_bucket/example gs://test_bucket/composed
gsutil cat gs://test_bucket/composed
```

Arguably, you may not want to use compose with a single file, but the API does allow it. This also makes it easier to process a list with compose, because you don't need to special case the case where you only have 1 value in the list.

This unit test works for me, but I needed to apply it against the previous commit. See #21 for a description of that issue.

I'm happy to sign Google's CLA.