### PR TITLE
Fix OauthRawGcsService::copyObject

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/cloudstorage/oauth/OauthRawGcsService.java
+++ b/java/src/main/java/com/google/appengine/tools/cloudstorage/oauth/OauthRawGcsService.java
@@ -645,7 +645,14 @@ final class OauthRawGcsService implements RawGcsService {
   public void copyObject(GcsFilename source, GcsFilename dest, GcsFileOptions fileOptions,
       long timeoutMillis) throws IOException {
     HTTPRequest req = makeRequest(dest, null, PUT, timeoutMillis);
-    req.setHeader(new HTTPHeader(X_GOOG_COPY_SOURCE, makePath(source)));
+
+    String sourcePath;
+    try {
+        sourcePath = new URI(null, null, makePath(source), null).toString();
+    } catch (URISyntaxException e) {
+	throw new RuntimeException("Failed to create path URI", e);
+    }
+    req.setHeader(new HTTPHeader(X_GOOG_COPY_SOURCE, sourcePath));
     if (fileOptions != null) {
       req.setHeader(REPLACE_METADATA_HEADER);
       addOptionsHeaders(req, fileOptions);


### PR DESCRIPTION
The documentation of [x-goog-copy-source](https://cloud.google.com/storage/docs/xml-api/reference-headers#xgoogcopy) says that the supplied path must be a legal URI and should generally be percent encoded.

This PR ensures that this is the case. Otherwise objects with `%` symbols and other special characters cannot be copied.
